### PR TITLE
Update biom-format recipe, pin h5py

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c8bac94ab6aa8226c0d38af7a3341d65e5f3664b9f45ec44fdf8b5275b2f92c1
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<36]
   entry_points:
     - biom = biom.cli:cli
@@ -23,14 +23,14 @@ requirements:
     - pip
     - cython
     - numpy >=1.9.2
-    - h5py
+    - h5py >=3.0.0
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - click
     - pandas >=0.20.0
     - scipy >=1.3.1
-    - h5py
+    - h5py >=3.0.0
 
 test:
   imports:


### PR DESCRIPTION
User @nano1231 reported a bug in biom-format, under issue biocore/biom-format#891, showing a sensitivity to `h5py < 3.0.0`. This PR sets a pin on the library version.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
